### PR TITLE
Feature: #30 커플 연동 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ### yml ###
 *-aws.yml
+
+### firebase ###
+/src/main/resources/firebase/lovebird-firebase-admin-sdk.json

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ dependencies {
 	// S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	// Firebase
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
+
 	// Spring Rest Docs
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 

--- a/src/main/java/com/ege/wooda/domain/member/domain/Member.java
+++ b/src/main/java/com/ege/wooda/domain/member/domain/Member.java
@@ -25,8 +25,10 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @Column(name = "device_token")
+    private String deviceToken;
 
+    @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     @CollectionTable(name = "member_role", joinColumns = @JoinColumn(name = "member_id"))
     @Column(name = "role")
@@ -43,6 +45,10 @@ public class Member {
         this.oauth2Entity = oauth2Entity;
         this.role = new ArrayList<>(List.of(Role.MEMBER));
         this.auditEntity = new AuditEntity();
+    }
+
+    public void registerDeviceToken(String deviceToken) {
+        this.deviceToken = deviceToken;
     }
 
     public List<SimpleGrantedAuthority> getRole() {

--- a/src/main/java/com/ege/wooda/domain/member/service/MemberService.java
+++ b/src/main/java/com/ege/wooda/domain/member/service/MemberService.java
@@ -24,6 +24,13 @@ public class MemberService {
                 () -> save(oAuth2Request.toOauth2Entity()));
     }
 
+    @Transactional
+    public void registerDeviceToken(Long id, String deviceToken) {
+        Member member = findById(id);
+        member.registerDeviceToken(deviceToken);
+
+    }
+
     public Member save(Oauth2Entity oauth2Entity) {
         return memberRepository.save(new Member(oauth2Entity));
     }

--- a/src/main/java/com/ege/wooda/domain/profile/controller/CoupleController.java
+++ b/src/main/java/com/ege/wooda/domain/profile/controller/CoupleController.java
@@ -1,0 +1,46 @@
+package com.ege.wooda.domain.profile.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ege.wooda.domain.profile.domain.Profile;
+import com.ege.wooda.domain.profile.dto.param.ConnectCoupleParam;
+import com.ege.wooda.domain.profile.dto.request.CoupleLinkRequest;
+import com.ege.wooda.domain.profile.dto.response.CoupleCodeResponse;
+import com.ege.wooda.domain.profile.dto.response.ProfileResponseMessage;
+import com.ege.wooda.domain.profile.service.CoupleService;
+import com.ege.wooda.global.common.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/{id}/profile")
+public class CoupleController {
+    private final CoupleService coupleService;
+
+    @PreAuthorize("#id == authentication.principal.id")
+    @GetMapping("/code")
+    public ResponseEntity<ApiResponse<CoupleCodeResponse>> generateCode(@PathVariable Long id) {
+        Profile profile = coupleService.updateCoupleCode(id);
+
+        return ResponseEntity.ok(
+                ApiResponse.createSuccessWithData(ProfileResponseMessage.GENERATE_COUPLE_CODE.getMessage(),
+                                                  profile.toCoupleCodeResponse()));
+    }
+
+    @PreAuthorize("#id == authentication.principal.id")
+    @PutMapping("/link")
+    public ResponseEntity<ApiResponse<?>> linkCouple(@PathVariable Long id,
+                                                          @RequestBody CoupleLinkRequest coupleLinkRequest) {
+        coupleService.connectCouple(new ConnectCoupleParam(id, coupleLinkRequest.coupleCode()));
+
+        return ResponseEntity.ok(ApiResponse.createSuccess(ProfileResponseMessage.LINK_SUCCESS.getMessage()));
+    }
+}

--- a/src/main/java/com/ege/wooda/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/ege/wooda/domain/profile/controller/ProfileController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.ege.wooda.domain.member.domain.enums.Gender;
+import com.ege.wooda.domain.member.service.MemberService;
 import com.ege.wooda.domain.profile.domain.Profile;
 import com.ege.wooda.domain.profile.dto.param.ProfileCreateParam;
 import com.ege.wooda.domain.profile.dto.param.ProfileUpdateParam;
@@ -32,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/{id}/profile")
 public class ProfileController {
     private final ProfileService profileService;
+    private final MemberService memberService;
 
     @PostMapping("")
     @PreAuthorize("#id == authentication.principal.id")
@@ -51,6 +53,7 @@ public class ProfileController {
                                                                   .build();
 
         Profile profile = profileService.save(profileCreateParam);
+        memberService.registerDeviceToken(id, profileCreateRequest.deviceToken());
 
         return new ResponseEntity<>(
                 ApiResponse.createSuccessWithData(ProfileResponseMessage.CREATE_PROFILE.getMessage(),

--- a/src/main/java/com/ege/wooda/domain/profile/domain/Profile.java
+++ b/src/main/java/com/ege/wooda/domain/profile/domain/Profile.java
@@ -9,6 +9,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import com.ege.wooda.domain.member.domain.enums.Gender;
 import com.ege.wooda.domain.profile.domain.enums.Anniversary;
+import com.ege.wooda.domain.profile.dto.response.CoupleCodeResponse;
 import com.ege.wooda.domain.profile.dto.response.ProfileDetailResponse;
 import com.ege.wooda.global.audit.AuditEntity;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -108,6 +109,19 @@ public class Profile {
         this.imageUrl = null;
     }
 
+    public void updateCoupleCode(String coupleCode) {
+        this.coupleCode = coupleCode;
+    }
+
+    public void deleteCoupleCode() { this.coupleCode = null; }
+
+    public void connectCouple(String coupleCode) {
+        this.coupleCode = coupleCode;
+        this.linkedFlag = true;
+    }
+
+    public void disconnectFlag() { this.linkedFlag = false; }
+
     public void update(Profile profile) {
         this.nickname = profile.getNickname();
         this.gender = profile.getGender();
@@ -126,5 +140,9 @@ public class Profile {
                                    .gender(gender.toString())
                                    .profileImageUrl(imageUrl)
                                    .build();
+    }
+
+    public CoupleCodeResponse toCoupleCodeResponse() {
+        return new CoupleCodeResponse(memberId, coupleCode);
     }
 }

--- a/src/main/java/com/ege/wooda/domain/profile/dto/param/ConnectCoupleParam.java
+++ b/src/main/java/com/ege/wooda/domain/profile/dto/param/ConnectCoupleParam.java
@@ -1,0 +1,5 @@
+package com.ege.wooda.domain.profile.dto.param;
+
+public record ConnectCoupleParam(Long memberId,
+                                 String coupleCode) {
+}

--- a/src/main/java/com/ege/wooda/domain/profile/dto/request/CoupleLinkRequest.java
+++ b/src/main/java/com/ege/wooda/domain/profile/dto/request/CoupleLinkRequest.java
@@ -1,0 +1,4 @@
+package com.ege.wooda.domain.profile.dto.request;
+
+public record CoupleLinkRequest(String coupleCode) {
+}

--- a/src/main/java/com/ege/wooda/domain/profile/dto/request/ProfileCreateRequest.java
+++ b/src/main/java/com/ege/wooda/domain/profile/dto/request/ProfileCreateRequest.java
@@ -3,6 +3,7 @@ package com.ege.wooda.domain.profile.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record ProfileCreateRequest(@NotBlank String nickname,
-                                  @NotBlank String firstDate,
-                                  @NotBlank String gender) {
+                                   @NotBlank String firstDate,
+                                   @NotBlank String gender,
+                                   @NotBlank String deviceToken) {
 }

--- a/src/main/java/com/ege/wooda/domain/profile/dto/response/CoupleCodeResponse.java
+++ b/src/main/java/com/ege/wooda/domain/profile/dto/response/CoupleCodeResponse.java
@@ -1,0 +1,5 @@
+package com.ege.wooda.domain.profile.dto.response;
+
+public record CoupleCodeResponse(Long memberId,
+                                 String coupleCode) {
+}

--- a/src/main/java/com/ege/wooda/domain/profile/dto/response/ProfileResponseMessage.java
+++ b/src/main/java/com/ege/wooda/domain/profile/dto/response/ProfileResponseMessage.java
@@ -9,6 +9,8 @@ public enum ProfileResponseMessage {
     CREATE_PROFILE("프로필이 생성되었습니다."),
     READ_PROFILE("프로필 조회에 성공하셨습니다."),
     READ_PROFILE_FAIL("프로필 조회에 실패하셨습니다."),
-    UPDATE_PROFILE("프로필이 성공적으로 수정되었습니다.");
+    UPDATE_PROFILE("프로필이 성공적으로 수정되었습니다."),
+    GENERATE_COUPLE_CODE("커플 연동 코드가 발급되었습니다."),
+    LINK_SUCCESS("커플 연동에 성공하셨습니다");
     private final String message;
 }

--- a/src/main/java/com/ege/wooda/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/ege/wooda/domain/profile/repository/ProfileRepository.java
@@ -11,5 +11,6 @@ import com.ege.wooda.domain.profile.domain.Profile;
 @Repository
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
     Optional<Profile> findProfileByMemberId(Long memberId);
+    Optional<Profile> findProfileByCoupleCode(String coupleCode);
     List<Profile> findProfileByCoupleCodeNotNullAndLinkedFlagIsFalse();
 }

--- a/src/main/java/com/ege/wooda/domain/profile/service/CoupleService.java
+++ b/src/main/java/com/ege/wooda/domain/profile/service/CoupleService.java
@@ -1,0 +1,56 @@
+package com.ege.wooda.domain.profile.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ege.wooda.domain.profile.domain.Profile;
+import com.ege.wooda.domain.profile.dto.param.ConnectCoupleParam;
+import com.ege.wooda.domain.profile.repository.ProfileRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CoupleService {
+    private final ProfileRepository profileRepository;
+
+    @Transactional
+    public Profile updateCoupleCode(Long memberId) {
+        Profile profile = findByMemberId(memberId);
+        profile.updateCoupleCode(generateCode());
+
+        // Scheduler 동작 필요
+
+        return profile;
+    }
+
+    @Transactional
+    public void connectCouple(ConnectCoupleParam connectCoupleParam) {
+        Profile self = findByMemberId(connectCoupleParam.memberId());
+        Profile partner = findByCoupleCode(connectCoupleParam.coupleCode());
+
+        self.connectCouple(connectCoupleParam.coupleCode());
+        partner.connectCouple(connectCoupleParam.coupleCode());
+
+        // FCM 필요
+    }
+
+    @Transactional(readOnly = true)
+    public Profile findByMemberId(Long memberId) {
+        return profileRepository.findProfileByMemberId(memberId).orElseThrow(EntityNotFoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public Profile findByCoupleCode(String coupleCode) {
+        return profileRepository.findProfileByCoupleCode(coupleCode).orElseThrow(EntityNotFoundException::new);
+    }
+
+    private String generateCode() {
+        return UUID.randomUUID().toString()
+                   .replaceAll("-", "")
+                   .substring(0, 8);
+    }
+}

--- a/src/main/java/com/ege/wooda/domain/profile/service/CoupleService.java
+++ b/src/main/java/com/ege/wooda/domain/profile/service/CoupleService.java
@@ -28,14 +28,14 @@ public class CoupleService {
     }
 
     @Transactional
-    public void connectCouple(ConnectCoupleParam connectCoupleParam) {
+    public Long connectCouple(ConnectCoupleParam connectCoupleParam) {
         Profile self = findByMemberId(connectCoupleParam.memberId());
         Profile partner = findByCoupleCode(connectCoupleParam.coupleCode());
 
         self.connectCouple(connectCoupleParam.coupleCode());
         partner.connectCouple(connectCoupleParam.coupleCode());
 
-        // FCM 필요
+        return partner.getMemberId();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ege/wooda/domain/profile/service/CoupleService.java
+++ b/src/main/java/com/ege/wooda/domain/profile/service/CoupleService.java
@@ -1,6 +1,11 @@
 package com.ege.wooda.domain.profile.service;
 
+import static java.util.Objects.isNull;
+
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +27,7 @@ public class CoupleService {
         Profile profile = findByMemberId(memberId);
         profile.updateCoupleCode(generateCode());
 
-        // Scheduler 동작 필요
+        scheduleCodeReset(profile);
 
         return profile;
     }
@@ -52,5 +57,16 @@ public class CoupleService {
         return UUID.randomUUID().toString()
                    .replaceAll("-", "")
                    .substring(0, 8);
+    }
+
+    private void scheduleCodeReset(Profile profile) {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+        executor.schedule(() -> {
+            if (!profile.getLinkedFlag() && !isNull(profile.getCoupleCode())) {
+                profile.deleteCoupleCode();
+            }
+        }, 24, TimeUnit.HOURS);
+        executor.shutdown();
     }
 }

--- a/src/main/java/com/ege/wooda/global/config/firebase/FirebaseConfig.java
+++ b/src/main/java/com/ege/wooda/global/config/firebase/FirebaseConfig.java
@@ -1,0 +1,33 @@
+package com.ege.wooda.global.config.firebase;
+
+import java.io.IOException;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+
+@Configuration
+public class FirebaseConfig {
+    private final ClassPathResource firebaseResource = new ClassPathResource(
+            "firebase/lovebird-firebase-admin-sdk.json");
+
+    @Bean
+    FirebaseApp firebaseApp() throws IOException {
+        FirebaseOptions options = FirebaseOptions.builder()
+                                                 .setCredentials(GoogleCredentials.fromStream(
+                                                         firebaseResource.getInputStream()))
+                                                 .build();
+
+        return FirebaseApp.initializeApp(options);
+    }
+
+    @Bean
+    FirebaseMessaging firebaseMessaging() throws IOException {
+        return FirebaseMessaging.getInstance(firebaseApp());
+    }
+}

--- a/src/main/java/com/ege/wooda/global/firebase/dto/NotificationRequest.java
+++ b/src/main/java/com/ege/wooda/global/firebase/dto/NotificationRequest.java
@@ -1,0 +1,21 @@
+package com.ege.wooda.global.firebase.dto;
+
+import com.google.firebase.messaging.Notification;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+public record NotificationRequest(@NotBlank String deviceToken,
+                                  String title,
+                                  String body) {
+
+    @Builder
+    public NotificationRequest {}
+
+    public Notification toNotification() {
+        return Notification.builder()
+                           .setTitle(title)
+                           .setBody(body)
+                           .build();
+    }
+}

--- a/src/main/java/com/ege/wooda/global/firebase/service/FCMService.java
+++ b/src/main/java/com/ege/wooda/global/firebase/service/FCMService.java
@@ -1,0 +1,25 @@
+package com.ege.wooda.global.firebase.service;
+
+import org.springframework.stereotype.Service;
+
+import com.ege.wooda.global.firebase.dto.NotificationRequest;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FCMService {
+    private final FirebaseMessaging firebaseMessaging;
+
+    public void sendNotification(NotificationRequest notificationRequest) throws FirebaseMessagingException {
+        Message message = Message.builder()
+                                 .setToken(notificationRequest.deviceToken())
+                                 .setNotification(notificationRequest.toNotification())
+                                 .build();
+
+        firebaseMessaging.send(message);
+    }
+}


### PR DESCRIPTION
> ### PR Introduce

- #30 

> ### Description

- 커플 연동 API 구현
  - coupleCode 발급
  - 커플 연동
- 연동 시 상대방에게 FCM 푸시 알림을 보내는 기능 구현

> ### Core Features

```java
@Service
@RequiredArgsConstructor
public class FCMService {
    private final FirebaseMessaging firebaseMessaging;

    public void sendNotification(NotificationRequest notificationRequest) throws FirebaseMessagingException {
        Message message = Message.builder()
                                 .setToken(notificationRequest.deviceToken())
                                 .setNotification(notificationRequest.toNotification())
                                 .build();

        firebaseMessaging.send(message);
    }
}
```

> ### Prev

```java
. . .
public class ProfileController {
    private final ProfileService profileService;

    @PostMapping("")
    @PreAuthorize("#id == authentication.principal.id")
    public ResponseEntity<ApiResponse<ProfileDetailResponse>> add(. . .)throws IOException {

        . . .

        Profile profile = profileService.save(profileCreateParam);
        . . .
     }
    . . .
}
```

> ### Changed

```java
. . .
public class ProfileController {
    private final ProfileService profileService;
    private final MemberService memberService;      // MemberService 주입

    @PostMapping("")
    @PreAuthorize("#id == authentication.principal.id")
    public ResponseEntity<ApiResponse<ProfileDetailResponse>> add(. . .) throws IOException {
        . . .

        Profile profile = profileService.save(profileCreateParam);
        memberService.registerDeviceToken(id, profileCreateRequest.deviceToken());      // device token 등록
```

> ### etc

- 테스트 코드 작성 X
